### PR TITLE
Fix header fade animation

### DIFF
--- a/src/app/components/TypingArea.tsx
+++ b/src/app/components/TypingArea.tsx
@@ -117,9 +117,9 @@ const TypingArea: React.FC<TypingAreaProps> = ({
       ref={typingContainerRef}
       tabIndex={0}
       onKeyDown={handleTyping}
-      className="relative w-full overflow-hidden outline-none flex flex-col justify-center items-center"
+      className="w-full overflow-hidden outline-none flex flex-col "
     >
-      <div className="line-wrapper typing-container">
+      <div className="space-y-4">
         {lines
           .slice(currentLineIndex, currentLineIndex + 6)
           .map((line, lineIndex) => (

--- a/src/app/components/TypingArea.tsx
+++ b/src/app/components/TypingArea.tsx
@@ -117,9 +117,9 @@ const TypingArea: React.FC<TypingAreaProps> = ({
       ref={typingContainerRef}
       tabIndex={0}
       onKeyDown={handleTyping}
-      className="w-full overflow-hidden outline-none flex flex-col "
+      className="relative w-full overflow-hidden outline-none flex flex-col justify-center items-center"
     >
-      <div className="space-y-4">
+      <div className="line-wrapper typing-container">
         {lines
           .slice(currentLineIndex, currentLineIndex + 6)
           .map((line, lineIndex) => (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -68,7 +68,7 @@ const Main: React.FC = () => {
       <div className="min-h-screen overflow-x-auto flex flex-col justify-center items-center mr-52 ">
         <div className="w-full max-w-4xl">
           <div
-            className={`transition-opacity duration-500${
+            className={`transition-opacity duration-500 ${
               isTypingStarted ? "opacity-0 pointer-events-none" : "opacity-100"
             }`}
           >


### PR DESCRIPTION
## Summary
- keep typing area centered while header fades away

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687420af6d54832cb34a619ab59f7031