### PR TITLE
Fix header fade spacing

### DIFF
--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -54,13 +54,15 @@ const Header: React.FC<HeaderProps> = ({
         </span>
 
         <span className="">\</span>
-        <div className="hover:text-[#f6f6f6] transition-colors duration-[350ms]">
-          <Link href="https://leetcode.com">Leetcode.com</Link>{" "}
+        <div>
+          <Link href="https://leetcode.com" className="interactive-item">
+            Leetcode.com
+          </Link>{" "}
         </div>
         <span className="">\</span>
         <div>
           <DropdownMenu>
-            <DropdownMenuTrigger className="rounded-lg hover:text-[#f6f6f6] transition-colors duration-[350ms] flex items-center">
+            <DropdownMenuTrigger className="interactive-item rounded-lg flex items-center">
               {selectedLanguage}
             </DropdownMenuTrigger>
             <DropdownMenuContent className="bg-black text-[#f6f6f6]">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -55,3 +55,35 @@ body {
 .dropdown-close-animation {
   animation: fade-out-up 0.2s ease-in-out forwards;
 }
+
+/* Shared styling for interactive header items */
+.interactive-item {
+  position: relative;
+  transition: color 0.35s, transform 0.35s;
+}
+
+.interactive-item::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: -2px;
+  width: 0;
+  height: 1px;
+  background-color: currentColor;
+  transition: width 0.35s;
+}
+
+.interactive-item:hover {
+  color: #f6f6f6;
+  transform: translateY(-2px);
+}
+
+.interactive-item:hover::after,
+.interactive-item.active::after {
+  width: 100%;
+}
+
+.interactive-item.active {
+  color: #f6f6f6;
+  transform: translateY(-2px);
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -68,7 +68,7 @@ const Main: React.FC = () => {
       <div className="min-h-screen overflow-x-auto flex flex-col justify-center items-center mr-52 ">
         <div className="w-full max-w-4xl">
           <div
-            className={`transition-opacity duration-500${
+            className={`transition-opacity duration-500 ${
               isTypingStarted ? "opacity-0 pointer-events-none" : "opacity-100"
             }`}
           >

--- a/src/components/ui/combobox.tsx
+++ b/src/components/ui/combobox.tsx
@@ -47,17 +47,14 @@ const Combobox: React.FC<ComboboxProps> = ({
   const menuId = React.useId();
 
   return (
-    <div
-      ref={boxRef}
-      className="relative hover:text-[#f6f6f6] transition-colors duration-[350ms]"
-    >
+    <div ref={boxRef} className="relative">
       <button
         type="button"
         role="combobox"
         aria-expanded={open}
         aria-controls={menuId}
         onClick={() => (open ? closeMenu() : setOpen(true))}
-        className="w-96 flex text-center justify-between items-center rounded px-1 py-1 "
+        className={`w-96 flex text-center justify-between items-center rounded px-1 py-1 interactive-item ${open ? "active" : ""}`}
       >
         {value || placeholder}
       </button>

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -50,14 +50,16 @@ export const DropdownMenu: React.FC<{ children: React.ReactNode }> = ({ children
 };
 
 export const DropdownMenuTrigger = React.forwardRef<HTMLButtonElement, React.ButtonHTMLAttributes<HTMLButtonElement>>(
-  ({ children, ...props }, ref) => {
+  ({ children, className = "", ...props }, ref) => {
     const context = useContext(DropdownMenuContext);
     if (!context) throw new Error("DropdownMenu components must be used within DropdownMenu");
     const { open, setOpen, closeMenu } = context;
+    const classes = `interactive-item rounded-lg flex items-center ${open ? "active" : ""} ${className}`;
     return (
       <button
         ref={ref}
         onClick={() => (open ? closeMenu() : setOpen(true))}
+        className={classes}
         {...props}
       >
         {children}


### PR DESCRIPTION
## Summary
- correct spacing in header fade class
- revert typing container styles so content spacing works
- add interactive underline animation for dropdowns and link

## Testing
- `npm run lint` *(fails: `next` not found)*


------
https://chatgpt.com/codex/tasks/task_e_687420af6d54832cb34a619ab59f7031