### PR TITLE
Add restart shortcut

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -54,14 +54,26 @@ const Main: React.FC = () => {
     }
   };
 
-  const handleTypingComplete = (errors: number) => {
-    setTotalErrors(errors);
-    if (startTime) {
-      const endTime = Date.now();
-      setTimeElapsed((endTime - startTime) / 1000); // Convert ms to seconds
-    }
-    setTypingComplete(true);
-  };
+const handleTypingComplete = (errors: number) => {
+  setTotalErrors(errors);
+  if (startTime) {
+    const endTime = Date.now();
+    setTimeElapsed((endTime - startTime) / 1000); // Convert ms to seconds
+  }
+  setTypingComplete(true);
+};
+
+  useEffect(() => {
+    const handleRestart = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === "Tab") {
+        e.preventDefault();
+        window.location.href = "/";
+      }
+    };
+
+    window.addEventListener("keydown", handleRestart);
+    return () => window.removeEventListener("keydown", handleRestart);
+  }, []);
 
   return (
     <div className="bg-black relative">


### PR DESCRIPTION
## Summary
- add keyboard listener for Ctrl/Cmd+Tab to restart typing session

## Testing
- `npm install` *(fails: internet disabled)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874a37000f4832cbf22391e1f8b9962