### PR TITLE
Implement restart fade animation

### DIFF
--- a/src/app/components/Results.tsx
+++ b/src/app/components/Results.tsx
@@ -127,7 +127,7 @@ const Results: React.FC<ResultsProps> = ({
       <div
         className={`${ibmPlexMono.className} text-[#646464] font-medium top-14 relative`}
       >
-        <span className="italic">ctrl/cmd + tab </span> {"  "} to restart
+        <span className="italic">tab + enter</span> to restart
       </div>
     </div>
   );

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -88,3 +88,12 @@ body {
   color: #f6f6f6;
   transform: translateY(-2px);
 }
+
+/* Disable interactions and selection when applied */
+.unselectable {
+  user-select: none;
+}
+
+.unselectable * {
+  pointer-events: none;
+}


### PR DESCRIPTION
## Summary
- fade TypingArea in on mount
- transition TypingArea out when restarting then back in
- fade out Results page on restart

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874b09e8c30832ca6afbef7a0147a4f