### PR TITLE
Show previous line while typing

### DIFF
--- a/src/app/components/TypingArea.tsx
+++ b/src/app/components/TypingArea.tsx
@@ -13,6 +13,9 @@ const TypingArea: React.FC<TypingAreaProps> = ({
 }) => {
   const [currentLineIndex, setCurrentLineIndex] = useState(0);
   const [typedChars, setTypedChars] = useState<string[]>([]);
+  // Store the typed characters of the previous line so it can remain
+  // visible for one extra iteration when the user moves to the next line
+  const [prevLineTypedChars, setPrevLineTypedChars] = useState<string[]>([]);
   const [charIndex, setCharIndex] = useState(0);
   const [cursorVisible, setCursorVisible] = useState(true);
   const [errorCount, setErrorCount] = useState(0);
@@ -97,6 +100,9 @@ const TypingArea: React.FC<TypingAreaProps> = ({
     ) {
       const nextLine = lines[currentLineIndex + 1];
       if (nextLine) {
+        // Preserve the typed characters of the line just completed
+        setPrevLineTypedChars(typedChars);
+
         const firstNonSpaceIndex = nextLine.search(/\S/);
         setCurrentLineIndex((prev) => prev + 1);
         setCharIndex(firstNonSpaceIndex >= 0 ? firstNonSpaceIndex : 0);
@@ -129,37 +135,50 @@ const TypingArea: React.FC<TypingAreaProps> = ({
       className="w-full overflow-hidden outline-none flex flex-col "
     >
       <div className={`space-y-4 ${lineTransition ? "slide-up" : ""}`}>
-        {lines
-          .slice(currentLineIndex, currentLineIndex + 6)
-          .map((line, lineIndex) => (
-            <div
-              key={lineIndex}
-              className={`transition-all duration-500 text-xl sm:text-xl md:text-3xl font-mono text-gray-300`}
-            >
-              {line.split("").map((char, index) => {
-                const isCursor = lineIndex === 0 && index === charIndex;
+        {(() => {
+          const sliceStart = Math.max(currentLineIndex - 1, 0);
+          return lines
+            .slice(sliceStart, sliceStart + 6)
+            .map((line, lineIndex) => {
+              const globalLineIndex = sliceStart + lineIndex;
+              const isCurrentLine = globalLineIndex === currentLineIndex;
+              const isPrevLine = globalLineIndex === currentLineIndex - 1;
+              return (
+                <div
+                  key={lineIndex}
+                  className="transition-all duration-500 text-xl sm:text-xl md:text-3xl font-mono text-gray-300"
+                >
+                  {line.split("").map((char, index) => {
+                    const isCursor = isCurrentLine && index === charIndex;
+                    const typedState = isCurrentLine
+                      ? typedChars[index]
+                      : isPrevLine
+                      ? prevLineTypedChars[index]
+                      : undefined;
 
-                return (
-                  <span
-                    key={index}
-                    className={`${
-                      lineIndex === 0 && typedChars[index] !== undefined
-                        ? typedChars[index] === "correct"
-                          ? "text-white"
-                          : char === " "
-                          ? "bg-red-500"
-                          : "text-red-500"
-                        : "text-gray-500"
-                    } ${
-                      isCursor && cursorVisible ? "bg-[#3c3c3c] text-black" : ""
-                    }`}
-                  >
-                    {char === " " ? "\u00A0" : char}
-                  </span>
-                );
-              })}
-            </div>
-          ))}
+                    return (
+                      <span
+                        key={index}
+                        className={`${
+                          typedState !== undefined
+                            ? typedState === "correct"
+                              ? "text-white"
+                              : char === " "
+                              ? "bg-red-500"
+                              : "text-red-500"
+                            : "text-gray-500"
+                        } ${
+                          isCursor && cursorVisible ? "bg-[#3c3c3c] text-black" : ""
+                        }`}
+                      >
+                        {char === " " ? "\u00A0" : char}
+                      </span>
+                    );
+                  })}
+                </div>
+              );
+            });
+        })()}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- keep last line's typed characters so it persists for one more step
- slice lines from one line above current and mark previous/current lines

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687574f4d3b8832c8b55391ee8b47f88